### PR TITLE
Older Android devices crash from calling `getNotificationChannel` (requires API level >= 26)

### DIFF
--- a/src/android/ParsePushPluginReceiver.java
+++ b/src/android/ParsePushPluginReceiver.java
@@ -147,14 +147,18 @@ public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver {
     PendingIntent deleteIntent = PendingIntent.getBroadcast(context, deleteIntentRequestCode, dIntent,
         PendingIntent.FLAG_UPDATE_CURRENT);
 
-    int importance = NotificationManager.IMPORTANCE_HIGH;
-    NotificationManager notifManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    NotificationChannel mChannel = notifManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
 
-    if (mChannel == null) {
-      mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_TITLE, importance);
-      mChannel.enableVibration(true);
-      notifManager.createNotificationChannel(mChannel);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      int importance = NotificationManager.IMPORTANCE_HIGH;
+      NotificationManager notifManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationChannel mChannel = notifManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
+
+      if (mChannel == null) {
+        mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_TITLE, importance);
+        mChannel.enableVibration(true);
+        notifManager.createNotificationChannel(mChannel);
+      }
     }
 
     NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID);

--- a/src/android/ParsePushPluginReceiver.java
+++ b/src/android/ParsePushPluginReceiver.java
@@ -154,7 +154,7 @@ public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver {
     if (mChannel == null) {
       mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_TITLE, importance);
       mChannel.enableVibration(true);
-      mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
+      mChannel.setVibrationPattern(new long[]{200, 300, 200});
       notifManager.createNotificationChannel(mChannel);
     }
 

--- a/src/android/ParsePushPluginReceiver.java
+++ b/src/android/ParsePushPluginReceiver.java
@@ -154,7 +154,6 @@ public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver {
     if (mChannel == null) {
       mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_TITLE, importance);
       mChannel.enableVibration(true);
-      mChannel.setVibrationPattern(new long[]{200, 300, 200});
       notifManager.createNotificationChannel(mChannel);
     }
 


### PR DESCRIPTION
Added a conditional check: creating the default channel only in case if Android API level is >= 26.